### PR TITLE
Fix ffmpeg run helper

### DIFF
--- a/ffmpeg_commands.py
+++ b/ffmpeg_commands.py
@@ -153,9 +153,22 @@ def create_ffmpeg_mix_audio_file_command(audio_file_1, audio_file_2, output_audi
     return " ".join(ffmpeg_command)
 
 def run(command):
+    """Execute an FFmpeg command.
+
+    The ``command`` argument can be either a string or a list. If a string is
+    provided ``subprocess.run`` is executed with ``shell=True`` so that complex
+    commands are handled correctly.
+    """
+
     try:
-        # Run the command using subprocess
-        result = subprocess.run(command, check=True) #, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # Run the command using subprocess. ``shell=True`` is required when the
+        # command is provided as a string with spaces.
+        if isinstance(command, str):
+            result = subprocess.run(command, shell=True, check=True)
+        else:
+            result = subprocess.run(command, check=True)
         print("FFmpeg command executed successfully.")
+        return result
     except subprocess.CalledProcessError as e:
         print("An error occurred while running FFmpeg:")
+        print(e)


### PR DESCRIPTION
## Summary
- handle both string and list commands in `ffmpeg_commands.run`
- add documentation and error output

## Testing
- `python -m py_compile correct_times.py main.py srt2csv.py wavs2wav.py ffmpeg_commands.py srt2audio.py vocabular.py`

------
https://chatgpt.com/codex/tasks/task_e_6862880f833483289f688fcd17b22cd2