### PR TITLE
Add pytest tests for time_to_seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ In records\one_voice directory will be created videos with suffix "_mix_out.mp4"
 Result must be:
 https://fex.net/ru/s/fctovr0
 
+## Running tests
+
+Install the dependencies listed in `requirements.txt` and run the test suite
+with [pytest](https://pytest.org/):
+
+```bash
+pytest
+```
+
 ToDo:
 
 1. Make something with short not-generated segments.

--- a/tests/test_correct_times.py
+++ b/tests/test_correct_times.py
@@ -1,0 +1,36 @@
+import sys
+import types
+import pytest
+
+# Provide a dummy soundfile module if it's missing so that correct_times can be imported
+if 'soundfile' not in sys.modules:
+    sys.modules['soundfile'] = types.ModuleType('soundfile')
+
+from correct_times import time_to_seconds
+
+@pytest.mark.parametrize(
+    'timestamp, expected',
+    [
+        ("00:00:00,000", 0.0),
+        ("00:01:02,003", 62.003),
+        ("01:02:03.123", 3723.123),
+        ("10:20:30,400", 37230.4),
+        ("23:59:59,999", 86399.999),
+    ],
+)
+def test_time_to_seconds_valid(timestamp, expected):
+    assert pytest.approx(time_to_seconds(timestamp), rel=1e-6) == expected
+
+@pytest.mark.parametrize(
+    'timestamp',
+    [
+        "not a time",
+        "01:02:03",  # missing milliseconds
+        "25:00:00,000",  # invalid hour
+        "12:60:00,000",  # invalid minute
+        "12:00:60,000",  # invalid second
+    ],
+)
+def test_time_to_seconds_invalid(timestamp):
+    with pytest.raises(ValueError):
+        time_to_seconds(timestamp)


### PR DESCRIPTION
## Summary
- add pytest tests for `time_to_seconds`
- document how to run tests with pytest

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628a7e20dc8328b6e47efb466b8e85