### PR TITLE
Fix accompaniment function spelling

### DIFF
--- a/ffmpeg_commands.py
+++ b/ffmpeg_commands.py
@@ -72,7 +72,7 @@ def adjust_volume_with_librosa(input_audio, output_audio, volume_intervals, k_vo
 
     print(f"Volume adjusted and saved to {output_audio}")
 
-def adjust_stereo_volume_with_librosa(input_audio, output_audio, volume_intervals, k_volume, acomponimemt):
+def adjust_stereo_volume_with_librosa(input_audio, output_audio, volume_intervals, k_volume, accompaniment):
     """
     Adjusts the volume of a stereo audio file using librosa.
 
@@ -83,7 +83,7 @@ def adjust_stereo_volume_with_librosa(input_audio, output_audio, volume_interval
     """
     # Load audio file with stereo channels
     y, sr = librosa.load(input_audio, sr=None, mono=False)
-    a, sr = librosa.load(acomponimemt, sr=None, mono=False)
+    a, sr = librosa.load(accompaniment, sr=None, mono=False)
 
     # Convert time to sample index
     for start_time, end_time in volume_intervals:

--- a/main.py
+++ b/main.py
@@ -9,10 +9,13 @@ import correct_times
 import wavs2wav
 import ffmpeg_commands
 import vocabular
-from wavs2wav import convert_mono_to_stereo, normalize_stereo_audio
+from wavs2wav import (
+    convert_mono_to_stereo,
+    normalize_stereo_audio,
+    extract_accompaniment_or_vocals,
+)
 from srt2csv import get_speakers_from_folder, check_texts, check_speeds_csv
 from vocabular import check_vocabular
-from wavs2wav import extract_acomponiment_or_vocals
 
 
 
@@ -70,18 +73,18 @@ def make_video_from(video_path, subtitle, speakers, default_speaker, vocabular_p
             command = ffmpeg_commands.extract_audio(video_path, out_ukr_wav) 
             ffmpeg_commands.run(command)
 
-        acomponiment = directory / f"{subtitle_name}_5.7_accompaniment_ukr.wav"
-        if not acomponiment.exists():
-            acomponiment_extracted = extract_acomponiment_or_vocals(directory, subtitle_name, out_ukr_wav)
-            normalize_stereo_audio(acomponiment_extracted, acomponiment)
-            os.remove(acomponiment_extracted)
+        accompaniment = directory / f"{subtitle_name}_5.7_accompaniment_ukr.wav"
+        if not accompaniment.exists():
+            accompaniment_extracted = extract_accompaniment_or_vocals(directory, subtitle_name, out_ukr_wav)
+            normalize_stereo_audio(accompaniment_extracted, accompaniment)
+            os.remove(accompaniment_extracted)
 
 
         output_audio = directory / f"{subtitle_name}_6_out_reduced_ukr.wav"
         if not output_audio.exists():
             volume_intervals = ffmpeg_commands.parse_volume_intervals(srt_csv_file)
             normalize_stereo_audio(out_ukr_wav, out_ukr_wav)
-            ffmpeg_commands.adjust_stereo_volume_with_librosa(out_ukr_wav, output_audio, volume_intervals, coef,acomponiment)
+            ffmpeg_commands.adjust_stereo_volume_with_librosa(out_ukr_wav, output_audio, volume_intervals, coef, accompaniment)
 
         # Make mix
         # mix_video = os.path.join(directory, f"{subtitle_name}_7_out_mix.mp4")

--- a/wavs2wav.py
+++ b/wavs2wav.py
@@ -8,26 +8,26 @@ import librosa
 import demucs.separate
 import shutil
 
-def extract_acomponiment_or_vocals(directory, subtitle_name, out_ukr_wav,
+def extract_accompaniment_or_vocals(directory, subtitle_name, out_ukr_wav,
         pipeline_suffix="_extracted.wav",
         model_demucs = "mdx_extra",
         sound_name="no_vocals.wav"
     ):
-    acomponiment = directory / f"{subtitle_name}{pipeline_suffix}"    
+    accompaniment = directory / f"{subtitle_name}{pipeline_suffix}"    
     model_folder = directory / model_demucs
     demucs_folder = model_folder / out_ukr_wav.stem
-    acomponiment_temp = demucs_folder / sound_name
+    accompaniment_temp = demucs_folder / sound_name
 
     demucs.separate.main(["--jobs", "4","-o", str(directory), "--two-stems", "vocals", "-n", model_demucs, str(out_ukr_wav)])
     
-    if acomponiment_temp.exists():
-        shutil.move(demucs_folder / sound_name, acomponiment)
+    if accompaniment_temp.exists():
+        shutil.move(demucs_folder / sound_name, accompaniment)
         shutil.rmtree(model_folder)
 
     # Verify the accompaniment exists and is valid
-    if not acomponiment.exists():
-        raise FileNotFoundError(f"Failed to extract accompaniment: {acomponiment}")
-    return acomponiment
+    if not accompaniment.exists():
+        raise FileNotFoundError(f"Failed to extract accompaniment: {accompaniment}")
+    return accompaniment
         
     
 


### PR DESCRIPTION
## Summary
- rename `extract_acomponiment_or_vocals` to `extract_accompaniment_or_vocals`
- update imports and variable names for new `accompaniment` spelling
- fix parameter name in `adjust_stereo_volume_with_librosa`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68628a465eb08328a8c5f765673da7aa