### PR TITLE
Improve vocabulary replacement logic

### DIFF
--- a/tests/test_correct_times.py
+++ b/tests/test_correct_times.py
@@ -1,6 +1,11 @@
 import sys
 import types
+from pathlib import Path
 import pytest
+
+# Ensure project root is on the path so local modules can be imported when
+# running `pytest` from any location.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 # Provide a dummy soundfile module if it's missing so that correct_times can be imported
 if 'soundfile' not in sys.modules:

--- a/tests/test_vocabular.py
+++ b/tests/test_vocabular.py
@@ -1,0 +1,39 @@
+import tempfile
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vocabular import modify_subtitles_with_vocabular_wholefile
+
+
+def test_whole_word_replacement_only_in_text():
+    srt_content = """1
+00:00:00,000 --> 00:00:01,000
+hello cat world
+
+2
+00:00:01,500 --> 00:00:02,000
+scattered catacombs
+"""
+    vocab_content = "cat<=>dog"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        srt_path = Path(tmpdir) / "in.srt"
+        vocab_path = Path(tmpdir) / "vocab.txt"
+        out_path = Path(tmpdir) / "out.srt"
+        srt_path.write_text(srt_content, encoding="utf-8")
+        vocab_path.write_text(vocab_content, encoding="utf-8")
+
+        modify_subtitles_with_vocabular_wholefile(srt_path, vocab_path, out_path)
+        result = out_path.read_text(encoding="utf-8")
+
+    expected = """1
+00:00:00,000 --> 00:00:01,000
+hello Dog world
+
+2
+00:00:01,500 --> 00:00:02,000
+scattered catacombs
+"""
+    assert result == expected


### PR DESCRIPTION
## Summary
- apply replacements only on subtitle text lines
- ensure replacements match whole words using regex boundaries
- update tests to load project modules reliably
- add regression test for vocabulary replacement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68820754e160832880a6e1736ccabf21