### PR TITLE
Switch to web-only interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ pip install f5-tts
 then install demucs (https://github.com/adefossez/demucs)
 python -m pip install -U demucs
 
-3. Run:
-python main.py --subtitle records\one_voice
+3. Run the web interface:
+python web_app.py
 
-In records\one_voice directory will be created videos with suffix "_mix_out.mp4"
+Open your browser at http://localhost:5000. Use the **Advanced** tab to adjust
+all parameters that were available in the console version. Output videos will be
+created in the selected folder with the specified suffix.
 
 Result must be:
 https://fex.net/ru/s/fctovr0

--- a/processor.py
+++ b/processor.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 from pathlib import Path
 
@@ -195,51 +194,20 @@ def fast_rglob(root_dir, extension, exclude_ext):  # for network drives
 
 
 
-def main():
-    # Initialize the argument parser
-    parser = argparse.ArgumentParser(description="Script that processes a subtitle file")
-
-    # Add a folder argument
-    parser.add_argument('--subtitle', type=str, help="Path to the subtitle folder to be processed",
-                        default=r"records")
-    # Add default tts speeds file
-    parser.add_argument('--speeds', type=str, help="Path to the speeds of tts",
-                        default="speeds.csv")
-    # Add delay to think that must be only one sentences, default value very very low
-    parser.add_argument('--delay', type=float, help="Delay to think that must be only one sentences",
-                        default=0.00001) 
-    # Add voice
-    parser.add_argument('--voice', type=str, help="Path to voice", default="basic_ref_en.wav")
-    # Add text
-    parser.add_argument('--text', type=str, help="Path to text for voice", default="some call me nature, others call me mother nature.")
-    # Add voice coeficient
-    parser.add_argument('--coef', type=float, help="Voice coeficient", default=0.2)
-    # Add video extension
-    parser.add_argument('--videoext', type=str, help="Video extension of video files", default=".mp4")
-    # Add subtitles extension
-    parser.add_argument('--srtext', type=str, help="Subtitle extension of files", default=".srt")
-    # Add out video ending
-    parser.add_argument('--outfileending', type=str, help="Out video file ending", default="_out_mix.mp4")
-    # Add vocabular
-    parser.add_argument('--vocabular', type=str, help="Vocabular of transcriptions", default="vocabular.txt")
-    # Add config
-    parser.add_argument('--config', "-c", type=str, help="Config file", default="basic.toml")
-
-    # Parse the arguments
-    args = parser.parse_args()
-
-    # Extract the folder argument
-    subtitle = args.subtitle
-    speeds = args.speeds
-    delay = args.delay
-    voice = args.voice
-    text = args.text
-    coef = args.coef
-    videoext = args.videoext
-    srtext = args.srtext
-    outfileending = args.outfileending
-    vocabular = args.vocabular
-
+def process_folder(
+    subtitle="records",
+    speeds="speeds.csv",
+    delay=0.00001,
+    voice="basic_ref_en.wav",
+    text="some call me nature, others call me mother nature.",
+    coef=0.2,
+    videoext=".mp4",
+    srtext=".srt",
+    outfileending="_out_mix.mp4",
+    vocabular="vocabular.txt",
+    config="basic.toml",
+    progress_callback=None,
+):
     subtitle_path = Path(subtitle)
     root_dir = subtitle_path.parent if subtitle_path.is_file() else subtitle_path
 
@@ -266,14 +234,16 @@ def main():
     for subtitle in sbt_files:
         subtitle = Path(subtitle)
         video_path = subtitle.with_suffix(videoext)
-        ready_video_file_name = subtitle.stem + "_out_mix.mp4"
+        ready_video_file_name = subtitle.stem + outfileending
         ready_video_path = video_path.parent / ready_video_file_name
         if video_path.is_file() and not ready_video_path.is_file():
-            make_video_from(video_path, subtitle, speakers, default_speaker, vocabular_pth, coef)
-
-
-
-if __name__ == "__main__":
-    main()
-
+            make_video_from(
+                video_path,
+                subtitle,
+                speakers,
+                default_speaker,
+                vocabular_pth,
+                coef,
+                progress_callback,
+            )
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,10 +3,31 @@
 <head>
     <meta charset="utf-8">
     <title>srt2audiotrack Web Interface</title>
+    <style>
+    .tab { display: none; }
+    .tab-active { display: block; }
+    </style>
     <script>
+    function showTab(id){
+        document.getElementById('basic').classList.remove('tab-active');
+        document.getElementById('advanced').classList.remove('tab-active');
+        document.getElementById(id).classList.add('tab-active');
+    }
     function startTask(){
-        const subtitle = document.getElementById('subtitle').value;
-        fetch('/start', {method: 'POST', body: new URLSearchParams({subtitle})})
+        const params = {
+            subtitle: document.getElementById('subtitle').value,
+            speeds: document.getElementById('speeds').value,
+            delay: document.getElementById('delay').value,
+            voice: document.getElementById('voice').value,
+            text: document.getElementById('text').value,
+            coef: document.getElementById('coef').value,
+            videoext: document.getElementById('videoext').value,
+            srtext: document.getElementById('srtext').value,
+            outfileending: document.getElementById('outfileending').value,
+            vocabular: document.getElementById('vocabular').value,
+            config: document.getElementById('config').value,
+        };
+        fetch('/start', {method: 'POST', body: new URLSearchParams(params)})
             .then(r => r.json())
             .then(_ => refresh());
     }
@@ -33,8 +54,24 @@
 <body>
     <h1>srt2audiotrack Web Interface</h1>
     <div>
+        <button onclick="showTab('basic')">Basic</button>
+        <button onclick="showTab('advanced')">Advanced</button>
+    </div>
+    <div id="basic" class="tab tab-active">
         Subtitle folder: <input id="subtitle" value="records">
         <button onclick="startTask()">Start</button>
+    </div>
+    <div id="advanced" class="tab">
+        <div>speeds: <input id="speeds" value="speeds.csv"></div>
+        <div>delay: <input id="delay" value="0.00001"></div>
+        <div>voice: <input id="voice" value="basic_ref_en.wav"></div>
+        <div>text: <input id="text" value="some call me nature, others call me mother nature."></div>
+        <div>coef: <input id="coef" value="0.2"></div>
+        <div>videoext: <input id="videoext" value=".mp4"></div>
+        <div>srtext: <input id="srtext" value=".srt"></div>
+        <div>outfileending: <input id="outfileending" value="_out_mix.mp4"></div>
+        <div>vocabular: <input id="vocabular" value="vocabular.txt"></div>
+        <div>config: <input id="config" value="basic.toml"></div>
     </div>
     <div>
         Workers: <input id="workers" value="{{ workers }}">

--- a/web_app.py
+++ b/web_app.py
@@ -1,8 +1,8 @@
 import threading
-import subprocess
 import uuid
 import time
 from flask import Flask, request, jsonify, render_template
+import processor
 
 app = Flask(__name__)
 
@@ -12,30 +12,21 @@ running = {}
 lock = threading.Lock()
 
 class Task:
-    def __init__(self, subtitle):
+    def __init__(self, params):
         self.id = str(uuid.uuid4())
-        self.subtitle = subtitle
+        self.params = params
         self.progress = 0
         self.status = 'queued'
         self.log = []
-        self.process = None
 
 
 def run_task(task: Task):
-    cmd = ['python', 'main.py', '--subtitle', task.subtitle]
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                               text=True, bufsize=1)
-    task.process = process
+    def progress(p, msg):
+        task.log.append(f"{p} {msg}")
+        task.progress = p
+
     task.status = 'running'
-    for line in process.stdout:
-        task.log.append(line)
-        if line.startswith('[PROGRESS]'):
-            try:
-                parts = line.strip().split(' ', 2)
-                task.progress = int(parts[1])
-            except Exception:
-                pass
-    process.wait()
+    processor.process_folder(progress_callback=progress, **task.params)
     task.status = 'finished'
     task.progress = 100
     with lock:
@@ -66,8 +57,20 @@ def index():
 
 @app.route('/start', methods=['POST'])
 def start():
-    subtitle = request.form.get('subtitle', 'records')
-    task = Task(subtitle)
+    params = {
+        'subtitle': request.form.get('subtitle', 'records'),
+        'speeds': request.form.get('speeds', 'speeds.csv'),
+        'delay': float(request.form.get('delay', '0.00001')),
+        'voice': request.form.get('voice', 'basic_ref_en.wav'),
+        'text': request.form.get('text', 'some call me nature, others call me mother nature.'),
+        'coef': float(request.form.get('coef', '0.2')),
+        'videoext': request.form.get('videoext', '.mp4'),
+        'srtext': request.form.get('srtext', '.srt'),
+        'outfileending': request.form.get('outfileending', '_out_mix.mp4'),
+        'vocabular': request.form.get('vocabular', 'vocabular.txt'),
+        'config': request.form.get('config', 'basic.toml'),
+    }
+    task = Task(params)
     tasks[task.id] = task
     return jsonify({'task_id': task.id})
 
@@ -83,7 +86,7 @@ def set_workers():
 @app.route('/tasks')
 def list_tasks():
     return jsonify({tid: {
-        'subtitle': t.subtitle,
+        'subtitle': t.params.get('subtitle'),
         'status': t.status,
         'progress': t.progress
     } for tid, t in tasks.items()})


### PR DESCRIPTION
## Summary
- drop CLI entrypoint and move logic to `processor.py`
- update Flask app to call the new processor directly
- add an advanced tab in `index.html` with all former CLI params
- remove console instructions and document how to run the web app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882609b68388328bd651ac8579d6d4d