### PR TITLE
Add output folder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ Run the main script by providing a folder that contains videos and matching `.sr
 ```bash
 python main.py --subtitle records\one_voice
 ```
-The processed videos will be saved in the same folder with the suffix `_out_mix.mp4`.
+The processed videos will be saved in the folder specified by `--output_folder`
+(or next to the subtitles if not provided) with the suffix `_out_mix.mp4`.
 
 ### Command line options
 - `--subtitle` – path to a folder or a single subtitle file.
 - `--videoext` – extension of the video files (default: `.mp4`).
 - `--srtext` – extension of subtitle files (default: `.srt`).
 - `--coef` – volume mix coefficient for the original audio (default: `0.2`).
+- `--output_folder` – directory where all intermediate and result files will be
+  stored.
 
 Run `python main.py -h` to see all available options.
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -16,10 +16,15 @@ from audio_utils import (
 )
 
 
-def prepare_subtitles(subtitle: Path, vocabular_pth: Path):
-    """Apply vocabulary corrections and return helper paths."""
-    directory = subtitle.with_suffix("")
-    directory.mkdir(exist_ok=True)
+def prepare_subtitles(subtitle: Path, vocabular_pth: Path, output_folder: Path):
+    """Apply vocabulary corrections and return helper paths.
+
+    All intermediate files are written inside ``output_folder`` under a
+    subdirectory named after the subtitle file stem.
+    """
+
+    directory = Path(output_folder) / subtitle.stem
+    directory.mkdir(parents=True, exist_ok=True)
     subtitle_name = subtitle.stem
     out_path = directory / f"{subtitle_name}_0_mod.srt"
 
@@ -135,7 +140,7 @@ def create_video_with_english_audio(
     coef: float,
     output_folder: Path,
 ):
-    directory, subtitle_name, out_path = prepare_subtitles(subtitle, vocabular_pth)
+    directory, subtitle_name, out_path = prepare_subtitles(subtitle, vocabular_pth, output_folder)
     srt_csv_file, stereo_eng_file = subtitles_to_audio(
         directory, subtitle_name, out_path, speakers, default_speaker
     )

--- a/tests/unit/test_output_folder.py
+++ b/tests/unit/test_output_folder.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import sys
+import os
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import vocabulary
+for name in ['subtitle_csv', 'tts_audio', 'sync_utils', 'ffmpeg_utils']:
+    sys.modules[name] = types.ModuleType(name)
+
+audio_stub = types.ModuleType('audio_utils')
+def _stub(*args, **kwargs):
+    pass
+audio_stub.convert_mono_to_stereo = _stub
+audio_stub.normalize_stereo_audio = _stub
+audio_stub.extract_acomponiment_or_vocals = _stub
+sys.modules['audio_utils'] = audio_stub
+sys.modules['vocabulary'] = vocabulary
+
+import pipeline
+
+def test_prepare_subtitles_creates_in_output_folder(tmp_path):
+    subtitle = tmp_path / "sample.srt"
+    subtitle.write_text("1\n00:00:00,000 --> 00:00:01,000\nhello\n")
+    vocab = tmp_path / "vocab.txt"
+    vocab.write_text("")
+    out_dir = tmp_path / "out"
+
+    directory, name, out_path = pipeline.prepare_subtitles(subtitle, vocab, out_dir)
+
+    assert name == "sample"
+    assert directory == out_dir / "sample"
+    assert out_path.exists()
+    assert out_path.parent == directory
+
+def test_create_video_with_english_audio_passes_output_folder(tmp_path, monkeypatch):
+    video = tmp_path / "video.mp4"
+    video.write_text("vid")
+    subtitle = tmp_path / "sample.srt"
+    subtitle.write_text("1\n00:00:00,000 --> 00:00:01,000\nhello\n")
+    vocab = tmp_path / "vocab.txt"
+    vocab.write_text("")
+    speakers = {"default_speaker_name": "spk", "spk": {"ref_text": "", "ref_file": ""}}
+    default_speaker = speakers["spk"]
+    out_dir = tmp_path / "out"
+
+    calls = {}
+    def fake_subtitles_to_audio(directory, subtitle_name, out_path, speakers, default_speaker):
+        calls["subdir"] = directory
+        return Path("dummy.csv"), Path("dummy.wav")
+    def fake_process_video_file(video_path_arg, directory, subtitle_name, srt_csv_file, stereo_eng_file, coef):
+        calls["procdir"] = directory
+
+    monkeypatch.setattr(pipeline, "subtitles_to_audio", fake_subtitles_to_audio)
+    monkeypatch.setattr(pipeline, "process_video_file", fake_process_video_file)
+
+    pipeline.create_video_with_english_audio(
+        str(video), subtitle, speakers, default_speaker, vocab, 0.1, out_dir
+    )
+
+    expected = out_dir / subtitle.stem
+    assert calls["subdir"] == expected
+    assert calls["procdir"] == expected


### PR DESCRIPTION
## Summary
- implement output folder parameter in `pipeline.prepare_subtitles` and propagate through `create_video_with_english_audio`
- document `--output_folder` command line option
- test output folder behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883a58b9bd083289476c8341ae2297e