### PR TITLE
Expose voice mix coefficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The processed videos will be saved in the folder specified by `--output_folder`
 - `--subtitle` – path to a folder or a single subtitle file.
 - `--videoext` – extension of the video files (default: `.mp4`).
 - `--srtext` – extension of subtitle files (default: `.srt`).
-- `--coef` – volume mix coefficient for the original audio (default: `0.2`).
-- `--output_folder` – directory where all intermediate and result files will be
-  stored.
+- `--acomponiment_coef` – mix coefficient for the original audio (default: `0.3`).
+- `--voice_coef` – proportion of generated voice in the final mix (default: `0.2`).
+- `--output_folder` – directory where all intermediate and result files will be stored.
 
 Run `python main.py -h` to see all available options.
 

--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -27,18 +27,27 @@ def extract_audio(input_video, output_audio):  #, volume_intervals, k_volume):
 
 
 
-def adjust_stereo_volume_with_librosa(input_audio, output_audio, volume_intervals, acomponimemt, acomponiment_coef, voice_coef=0.2):
+def adjust_stereo_volume_with_librosa(
+    input_audio,
+    output_audio,
+    volume_intervals,
+    acomponiment,
+    acomponiment_coef,
+    voice_coef=0.2,
+):
     """
     Adjusts the volume of a stereo audio file using librosa.
 
     :param input_audio: Path to input WAV file
     :param output_audio: Path to output WAV file
     :param volume_intervals: List of tuples (start_time, end_time) where volume needs adjustment
-    :param k_volume: Volume adjustment factor (e.g., 0.5 for 50% reduction, 1.5 for increase)
+    :param acomponiment: Path to extracted accompaniment audio
+    :param acomponiment_coef: Volume coefficient for the accompaniment track
+    :param voice_coef: Volume coefficient for the original voice
     """
     # Load audio file with stereo channels
     y, sr = librosa.load(input_audio, sr=None, mono=False)
-    a, sr = librosa.load(acomponimemt, sr=None, mono=False)
+    a, sr = librosa.load(acomponiment, sr=None, mono=False)
 
     # Convert time to sample index
     for start_time, end_time in volume_intervals:

--- a/main.py
+++ b/main.py
@@ -80,11 +80,12 @@ def main():
         ready_video_file_name = subtitle.stem + "_out_mix.mp4"
         ready_video_path = video_path.parent / ready_video_file_name
         if video_path.is_file() and not ready_video_path.is_file():
-            create_video_with_english_audio(video_path, 
-                                            subtitle, 
-                                            speakers, default_speaker, 
-                                            vocabular_pth, 
-                                            acomponiment_coef, 
+            create_video_with_english_audio(video_path,
+                                            subtitle,
+                                            speakers, default_speaker,
+                                            vocabular_pth,
+                                            acomponiment_coef,
+                                            voice_coef,
                                             output_folder)
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -89,7 +89,8 @@ def process_video_file(
     subtitle_name: str,
     srt_csv_file: Path,
     stereo_eng_file: Path,
-    coef: float,
+    acomponiment_coef: float,
+    voice_coef: float,
 ):
     """Process the input video and mix with generated audio."""
     if not os.path.exists(video_path):
@@ -113,7 +114,12 @@ def process_video_file(
         volume_intervals = ffmpeg_utils.parse_volume_intervals(srt_csv_file)
         normalize_stereo_audio(out_ukr_wav, out_ukr_wav)
         ffmpeg_utils.adjust_stereo_volume_with_librosa(
-            out_ukr_wav, output_audio, volume_intervals, acomponiment,  coef
+            out_ukr_wav,
+            output_audio,
+            volume_intervals,
+            acomponiment,
+            acomponiment_coef,
+            voice_coef,
         )
 
     ext = Path(video_path).suffix.lower()
@@ -137,7 +143,8 @@ def create_video_with_english_audio(
     speakers: dict,
     default_speaker: dict,
     vocabular_pth: Path,
-    coef: float,
+    acomponiment_coef: float,
+    voice_coef: float,
     output_folder: Path,
 ):
     directory, subtitle_name, out_path = prepare_subtitles(subtitle, vocabular_pth, output_folder)
@@ -145,7 +152,13 @@ def create_video_with_english_audio(
         directory, subtitle_name, out_path, speakers, default_speaker
     )
     process_video_file(
-        video_path, directory, subtitle_name, srt_csv_file, stereo_eng_file, coef
+        video_path,
+        directory,
+        subtitle_name,
+        srt_csv_file,
+        stereo_eng_file,
+        acomponiment_coef,
+        voice_coef,
     )
 
 

--- a/tests/unit/test_output_folder.py
+++ b/tests/unit/test_output_folder.py
@@ -49,14 +49,21 @@ def test_create_video_with_english_audio_passes_output_folder(tmp_path, monkeypa
     def fake_subtitles_to_audio(directory, subtitle_name, out_path, speakers, default_speaker):
         calls["subdir"] = directory
         return Path("dummy.csv"), Path("dummy.wav")
-    def fake_process_video_file(video_path_arg, directory, subtitle_name, srt_csv_file, stereo_eng_file, coef):
+    def fake_process_video_file(video_path_arg, directory, subtitle_name, srt_csv_file, stereo_eng_file, acomponiment_coef, voice_coef):
         calls["procdir"] = directory
 
     monkeypatch.setattr(pipeline, "subtitles_to_audio", fake_subtitles_to_audio)
     monkeypatch.setattr(pipeline, "process_video_file", fake_process_video_file)
 
     pipeline.create_video_with_english_audio(
-        str(video), subtitle, speakers, default_speaker, vocab, 0.1, out_dir
+        str(video),
+        subtitle,
+        speakers,
+        default_speaker,
+        vocab,
+        0.1,
+        0.2,
+        out_dir,
     )
 
     expected = out_dir / subtitle.stem


### PR DESCRIPTION
## Summary
- propagate `voice_coef` from CLI down to ffmpeg helper
- update `pipeline` functions to pass the coefficient
- fix unit tests for new API
- document the new command-line options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ae4dd5e48328a8f4a65ebfb0386b