### PR TITLE
Introduce SubtitlePipeline class

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,10 @@ import argparse
 from pathlib import Path
 from subtitle_csv import get_speakers_from_folder, check_texts, check_speeds_csv
 from vocabulary import check_vocabular
-from pipeline import create_video_with_english_audio, list_subtitle_files
+from pipeline import (
+    list_subtitle_files,
+    SubtitlePipeline,
+)
 
 
 def main():
@@ -80,13 +83,16 @@ def main():
         ready_video_file_name = subtitle.stem + "_out_mix.mp4"
         ready_video_path = video_path.parent / ready_video_file_name
         if video_path.is_file() and not ready_video_path.is_file():
-            create_video_with_english_audio(video_path,
-                                            subtitle,
-                                            speakers, default_speaker,
-                                            vocabular_pth,
-                                            acomponiment_coef,
-                                            voice_coef,
-                                            output_folder)
+            pipeline = SubtitlePipeline(
+                subtitle,
+                vocabular_pth,
+                speakers,
+                default_speaker,
+                acomponiment_coef,
+                voice_coef,
+                output_folder,
+            )
+            pipeline.run(video_path)
 
 
 


### PR DESCRIPTION
## Summary
- add a `SubtitlePipeline` class to encapsulate stateful pipeline logic
- update `main.py` to use the new class
- extend unit tests to cover `SubtitlePipeline`
- adjust test stubs for new import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ff139b788328b139d33ff5f44a05