### PR TITLE
Refactor pipeline helpers into class

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,10 +2,7 @@ import argparse
 from pathlib import Path
 from subtitle_csv import get_speakers_from_folder, check_texts, check_speeds_csv
 from vocabulary import check_vocabular
-from pipeline import (
-    list_subtitle_files,
-    SubtitlePipeline,
-)
+from pipeline import SubtitlePipeline
 
 
 def main():
@@ -73,7 +70,9 @@ def main():
         exit(1)
     default_speaker = speakers.get(speakers["default_speaker_name"])
 
-    sbt_files = list_subtitle_files(subtitle, srtext, exclude_ext="_0_mod.srt")
+    sbt_files = SubtitlePipeline.list_subtitle_files(
+        subtitle, srtext, exclude_ext="_0_mod.srt"
+    )
     # we need exclude srt modified files that we used for right pronunciation
     if Path(subtitle).is_file():
         sbt_files = [subtitle]

--- a/pipeline.py
+++ b/pipeline.py
@@ -12,165 +12,11 @@ import vocabulary
 from audio_utils import (
     convert_mono_to_stereo,
     normalize_stereo_audio,
-    extract_acomponiment_or_vocals, adjust_stereo_volume_with_librosa
+    extract_acomponiment_or_vocals,
+    adjust_stereo_volume_with_librosa,
 )
 
 
-def prepare_subtitles(subtitle: Path, vocabular_pth: Path, output_folder: Path):
-    """Apply vocabulary corrections and return helper paths.
-
-    All intermediate files are written inside ``output_folder`` under a
-    subdirectory named after the subtitle file stem.
-    """
-
-    directory = Path(output_folder) / subtitle.stem
-    directory.mkdir(parents=True, exist_ok=True)
-    subtitle_name = subtitle.stem
-    out_path = directory / f"{subtitle_name}_0_mod.srt"
-
-    if not out_path.exists():
-        vocabulary.modify_subtitles_with_vocabular_text_only(
-            subtitle, vocabular_pth, out_path
-        )
-
-    return directory, subtitle_name, out_path
-
-
-def subtitles_to_audio(directory: Path, subtitle_name: str, out_path: Path, speakers: dict, default_speaker: dict):
-    """Convert subtitles to CSV and generate English audio."""
-    srt_csv_file = directory / f"{subtitle_name}_1.0_srt.csv"
-    if not srt_csv_file.exists():
-        subtitle_csv.srt_to_csv(out_path, srt_csv_file)
-
-    output_csv_with_speakers = directory / f"{subtitle_name}_1.5_output_speakers.csv"
-    if not output_csv_with_speakers.exists():
-        subtitle_csv.add_speaker_columns(srt_csv_file, output_csv_with_speakers)
-
-    output_with_preview_speeds_csv = directory / f"{subtitle_name}_3.0_output_speed.csv"
-    if not output_with_preview_speeds_csv.exists():
-        subtitle_csv.add_speed_columns_with_speakers(
-            output_csv_with_speakers, speakers, output_with_preview_speeds_csv
-        )
-
-    if not tts_audio.F5TTS.all_segments_in_folder_check(
-        output_with_preview_speeds_csv, directory
-    ):
-        f5tts = tts_audio.F5TTS()
-        f5tts.generate_from_csv_with_speakers(
-            output_with_preview_speeds_csv,
-            directory,
-            speakers,
-            default_speaker,
-            rewrite=False,
-        )
-
-    corrected_time_output_speed_csv = directory / f"{subtitle_name}_4_corrected_output_speed.csv"
-    if not corrected_time_output_speed_csv.exists():
-        sync_utils.correct_end_times_in_csv(
-            directory, output_with_preview_speeds_csv, corrected_time_output_speed_csv
-        )
-
-    output_audio_file = directory / f"{subtitle_name}_5.0_output_audiotrack_eng.wav"
-    if not output_audio_file.exists():
-        audio_utils.collect_full_audiotrack(
-            directory, corrected_time_output_speed_csv, output_audio_file
-        )
-
-    stereo_eng_file = directory / f"{subtitle_name}_5.3_stereo_eng.wav"
-    if not stereo_eng_file.exists():
-        convert_mono_to_stereo(output_audio_file, stereo_eng_file)
-
-    return srt_csv_file, stereo_eng_file
-
-
-def process_video_file(
-    video_path: str,
-    directory: Path,
-    subtitle_name: str,
-    srt_csv_file: Path,
-    stereo_eng_file: Path,
-    acomponiment_coef: float,
-    voice_coef: float,
-):
-    """Process the input video and mix with generated audio."""
-    if not os.path.exists(video_path):
-        return
-
-    out_ukr_wav = directory / f"{subtitle_name}_5.5_out_ukr.wav"
-    if not out_ukr_wav.exists():
-        command = ffmpeg_utils.extract_audio(video_path, out_ukr_wav)
-        ffmpeg_utils.run(command)
-
-    acomponiment = directory / f"{subtitle_name}_5.7_accompaniment_ukr.wav"
-    if not acomponiment.exists():
-        acomponiment_extracted = extract_acomponiment_or_vocals(
-            directory, subtitle_name, out_ukr_wav
-        )
-        normalize_stereo_audio(acomponiment_extracted, acomponiment)
-        os.remove(acomponiment_extracted)
-
-    output_audio = directory / f"{subtitle_name}_6_out_reduced_ukr.wav"
-    if not output_audio.exists():
-        volume_intervals = ffmpeg_utils.parse_volume_intervals(srt_csv_file)
-        normalize_stereo_audio(out_ukr_wav, out_ukr_wav)
-        adjust_stereo_volume_with_librosa(
-            out_ukr_wav,
-            output_audio,
-            volume_intervals,
-            acomponiment,
-            acomponiment_coef,
-            voice_coef,
-        )
-
-    ext = Path(video_path).suffix.lower()
-    match ext:
-        case ".mp4" | ".mkv" | ".avi":
-            mix_video = directory.parent / f"{subtitle_name}_out_mix{ext}"
-        case _:
-            print(f"Unsupported video format: {video_path}")
-            return
-
-    if not mix_video.exists():
-        command = ffmpeg_utils.create_ffmpeg_mix_video_file_command(
-            video_path, output_audio, stereo_eng_file, mix_video
-        )
-        ffmpeg_utils.run(command)
-
-
-def create_video_with_english_audio(
-    video_path: str,
-    subtitle: Path,
-    speakers: dict,
-    default_speaker: dict,
-    vocabular_pth: Path,
-    acomponiment_coef: float,
-    voice_coef: float,
-    output_folder: Path,
-):
-    directory, subtitle_name, out_path = prepare_subtitles(subtitle, vocabular_pth, output_folder)
-    srt_csv_file, stereo_eng_file = subtitles_to_audio(
-        directory, subtitle_name, out_path, speakers, default_speaker
-    )
-    process_video_file(
-        video_path,
-        directory,
-        subtitle_name,
-        srt_csv_file,
-        stereo_eng_file,
-        acomponiment_coef,
-        voice_coef,
-    )
-
-
-def list_subtitle_files(root_dir: str | Path, extension: str, exclude_ext: str):
-    """Recursively search for files with the given extension, excluding modified files."""
-    ext = extension.lstrip('.')
-    sbt_files = []
-    for dirpath, _, filenames in os.walk(root_dir):
-        for file in filenames:
-            if file.endswith(f".{ext}") and not file.endswith(exclude_ext):
-                sbt_files.append(os.path.join(dirpath, file))
-    return sbt_files
 
 
 class SubtitlePipeline:
@@ -200,8 +46,172 @@ class SubtitlePipeline:
         self.srt_csv_file: Path | None = None
         self.stereo_eng_file: Path | None = None
 
+    @staticmethod
+    def prepare_subtitles(
+        subtitle: Path, vocabular_pth: Path, output_folder: Path
+    ) -> tuple[Path, str, Path]:
+        """Apply vocabulary corrections and return helper paths."""
+        directory = Path(output_folder) / subtitle.stem
+        directory.mkdir(parents=True, exist_ok=True)
+        subtitle_name = subtitle.stem
+        out_path = directory / f"{subtitle_name}_0_mod.srt"
+
+        if not out_path.exists():
+            vocabulary.modify_subtitles_with_vocabular_text_only(
+                subtitle, vocabular_pth, out_path
+            )
+
+        return directory, subtitle_name, out_path
+
+    @staticmethod
+    def subtitles_to_audio(
+        directory: Path,
+        subtitle_name: str,
+        out_path: Path,
+        speakers: dict,
+        default_speaker: dict,
+    ) -> tuple[Path, Path]:
+        """Convert subtitles to CSV and generate English audio."""
+        srt_csv_file = directory / f"{subtitle_name}_1.0_srt.csv"
+        if not srt_csv_file.exists():
+            subtitle_csv.srt_to_csv(out_path, srt_csv_file)
+
+        output_csv_with_speakers = directory / f"{subtitle_name}_1.5_output_speakers.csv"
+        if not output_csv_with_speakers.exists():
+            subtitle_csv.add_speaker_columns(srt_csv_file, output_csv_with_speakers)
+
+        output_with_preview_speeds_csv = directory / f"{subtitle_name}_3.0_output_speed.csv"
+        if not output_with_preview_speeds_csv.exists():
+            subtitle_csv.add_speed_columns_with_speakers(
+                output_csv_with_speakers, speakers, output_with_preview_speeds_csv
+            )
+
+        if not tts_audio.F5TTS.all_segments_in_folder_check(
+            output_with_preview_speeds_csv, directory
+        ):
+            f5tts = tts_audio.F5TTS()
+            f5tts.generate_from_csv_with_speakers(
+                output_with_preview_speeds_csv,
+                directory,
+                speakers,
+                default_speaker,
+                rewrite=False,
+            )
+
+        corrected_time_output_speed_csv = directory / f"{subtitle_name}_4_corrected_output_speed.csv"
+        if not corrected_time_output_speed_csv.exists():
+            sync_utils.correct_end_times_in_csv(
+                directory, output_with_preview_speeds_csv, corrected_time_output_speed_csv
+            )
+
+        output_audio_file = directory / f"{subtitle_name}_5.0_output_audiotrack_eng.wav"
+        if not output_audio_file.exists():
+            audio_utils.collect_full_audiotrack(
+                directory, corrected_time_output_speed_csv, output_audio_file
+            )
+
+        stereo_eng_file = directory / f"{subtitle_name}_5.3_stereo_eng.wav"
+        if not stereo_eng_file.exists():
+            convert_mono_to_stereo(output_audio_file, stereo_eng_file)
+
+        return srt_csv_file, stereo_eng_file
+
+    @staticmethod
+    def process_video_file(
+        video_path: str,
+        directory: Path,
+        subtitle_name: str,
+        srt_csv_file: Path,
+        stereo_eng_file: Path,
+        acomponiment_coef: float,
+        voice_coef: float,
+    ) -> None:
+        """Process the input video and mix with generated audio."""
+        if not os.path.exists(video_path):
+            return
+
+        out_ukr_wav = directory / f"{subtitle_name}_5.5_out_ukr.wav"
+        if not out_ukr_wav.exists():
+            command = ffmpeg_utils.extract_audio(video_path, out_ukr_wav)
+            ffmpeg_utils.run(command)
+
+        acomponiment = directory / f"{subtitle_name}_5.7_accompaniment_ukr.wav"
+        if not acomponiment.exists():
+            acomponiment_extracted = extract_acomponiment_or_vocals(
+                directory, subtitle_name, out_ukr_wav
+            )
+            normalize_stereo_audio(acomponiment_extracted, acomponiment)
+            os.remove(acomponiment_extracted)
+
+        output_audio = directory / f"{subtitle_name}_6_out_reduced_ukr.wav"
+        if not output_audio.exists():
+            volume_intervals = ffmpeg_utils.parse_volume_intervals(srt_csv_file)
+            normalize_stereo_audio(out_ukr_wav, out_ukr_wav)
+            adjust_stereo_volume_with_librosa(
+                out_ukr_wav,
+                output_audio,
+                volume_intervals,
+                acomponiment,
+                acomponiment_coef,
+                voice_coef,
+            )
+
+        ext = Path(video_path).suffix.lower()
+        match ext:
+            case ".mp4" | ".mkv" | ".avi":
+                mix_video = directory.parent / f"{subtitle_name}_out_mix{ext}"
+            case _:
+                print(f"Unsupported video format: {video_path}")
+                return
+
+        if not mix_video.exists():
+            command = ffmpeg_utils.create_ffmpeg_mix_video_file_command(
+                video_path, output_audio, stereo_eng_file, mix_video
+            )
+            ffmpeg_utils.run(command)
+
+    @classmethod
+    def create_video_with_english_audio(
+        cls,
+        video_path: str,
+        subtitle: Path,
+        speakers: dict,
+        default_speaker: dict,
+        vocabular_pth: Path,
+        acomponiment_coef: float,
+        voice_coef: float,
+        output_folder: Path,
+    ) -> None:
+        """High level helper that runs the full pipeline."""
+        directory, subtitle_name, out_path = cls.prepare_subtitles(
+            subtitle, vocabular_pth, output_folder
+        )
+        srt_csv_file, stereo_eng_file = cls.subtitles_to_audio(
+            directory, subtitle_name, out_path, speakers, default_speaker
+        )
+        cls.process_video_file(
+            video_path,
+            directory,
+            subtitle_name,
+            srt_csv_file,
+            stereo_eng_file,
+            acomponiment_coef,
+            voice_coef,
+        )
+
+    @staticmethod
+    def list_subtitle_files(root_dir: str | Path, extension: str, exclude_ext: str) -> list[str]:
+        """Recursively search for files with the given extension, excluding modified files."""
+        ext = extension.lstrip('.')
+        sbt_files = []
+        for dirpath, _, filenames in os.walk(root_dir):
+            for file in filenames:
+                if file.endswith(f".{ext}") and not file.endswith(exclude_ext):
+                    sbt_files.append(os.path.join(dirpath, file))
+        return sbt_files
+
     def prepare(self) -> None:
-        self.directory, self.subtitle_name, self.out_path = prepare_subtitles(
+        self.directory, self.subtitle_name, self.out_path = self.prepare_subtitles(
             self.subtitle,
             self.vocabular,
             self.output_folder,
@@ -209,7 +219,7 @@ class SubtitlePipeline:
 
     def generate_audio(self) -> None:
         assert self.directory is not None and self.subtitle_name is not None and self.out_path is not None
-        self.srt_csv_file, self.stereo_eng_file = subtitles_to_audio(
+        self.srt_csv_file, self.stereo_eng_file = self.subtitles_to_audio(
             self.directory,
             self.subtitle_name,
             self.out_path,
@@ -221,7 +231,7 @@ class SubtitlePipeline:
         assert self.directory is not None
         assert self.subtitle_name is not None
         assert self.srt_csv_file is not None and self.stereo_eng_file is not None
-        process_video_file(
+        self.process_video_file(
             video_path,
             self.directory,
             self.subtitle_name,

--- a/tests/unit/test_output_folder.py
+++ b/tests/unit/test_output_folder.py
@@ -28,7 +28,9 @@ def test_prepare_subtitles_creates_in_output_folder(tmp_path):
     vocab.write_text("")
     out_dir = tmp_path / "out"
 
-    directory, name, out_path = pipeline.prepare_subtitles(subtitle, vocab, out_dir)
+    directory, name, out_path = pipeline.SubtitlePipeline.prepare_subtitles(
+        subtitle, vocab, out_dir
+    )
 
     assert name == "sample"
     assert directory == out_dir / "sample"
@@ -53,10 +55,14 @@ def test_create_video_with_english_audio_passes_output_folder(tmp_path, monkeypa
     def fake_process_video_file(video_path_arg, directory, subtitle_name, srt_csv_file, stereo_eng_file, acomponiment_coef, voice_coef):
         calls["procdir"] = directory
 
-    monkeypatch.setattr(pipeline, "subtitles_to_audio", fake_subtitles_to_audio)
-    monkeypatch.setattr(pipeline, "process_video_file", fake_process_video_file)
+    monkeypatch.setattr(
+        pipeline.SubtitlePipeline, "subtitles_to_audio", staticmethod(fake_subtitles_to_audio)
+    )
+    monkeypatch.setattr(
+        pipeline.SubtitlePipeline, "process_video_file", staticmethod(fake_process_video_file)
+    )
 
-    pipeline.create_video_with_english_audio(
+    pipeline.SubtitlePipeline.create_video_with_english_audio(
         str(video),
         subtitle,
         speakers,
@@ -96,9 +102,15 @@ def test_subtitle_pipeline_run_uses_output_folder(tmp_path, monkeypatch):
     def fake_process_video_file(video_path_arg, directory, subtitle_name, srt_csv_file, stereo_eng_file, acomp, voice):
         calls["video"] = directory
 
-    monkeypatch.setattr(pipeline, "prepare_subtitles", fake_prepare_subtitles)
-    monkeypatch.setattr(pipeline, "subtitles_to_audio", fake_subtitles_to_audio)
-    monkeypatch.setattr(pipeline, "process_video_file", fake_process_video_file)
+    monkeypatch.setattr(
+        pipeline.SubtitlePipeline, "prepare_subtitles", staticmethod(fake_prepare_subtitles)
+    )
+    monkeypatch.setattr(
+        pipeline.SubtitlePipeline, "subtitles_to_audio", staticmethod(fake_subtitles_to_audio)
+    )
+    monkeypatch.setattr(
+        pipeline.SubtitlePipeline, "process_video_file", staticmethod(fake_process_video_file)
+    )
 
     sp = pipeline.SubtitlePipeline(
         subtitle,


### PR DESCRIPTION
## Summary
- move helper functions (`prepare_subtitles`, `subtitles_to_audio`, `process_video_file`, `create_video_with_english_audio`, `list_subtitle_files`) into `SubtitlePipeline` as static/class methods
- update main script to use the new class methods
- adjust unit tests for new method locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884058b6f3c8328b53be38bbf8eea67