### PR TITLE
Fix SubtitlePipeline API

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -54,9 +54,32 @@ class SubtitlePipeline:
         self.mix_video = self.output_folder / f"{self.subtitle_name}_out_mix.mp4"
 
     def run(self, video_path: str) -> None:
+        """Run the full processing pipeline for ``video_path``."""
+        # The public ``run`` method orchestrates the high level steps using
+        # the public helper methods so that tests can monkeypatch them.
+        self.prepare_subtitles()
+        self.subtitles_to_audio()
+        self.process_video_file(video_path)
+
+    # ------------------------------------------------------------------
+    # Public helper methods expected by the tests.  These methods simply
+    # wrap the private implementation details so that unit tests can
+    # monkeypatch them without relying on the internal method names.
+    # ------------------------------------------------------------------
+
+    def prepare_subtitles(self) -> tuple[Path, str, Path]:
+        """Prepare subtitle files and return output locations."""
         self.directory.mkdir(parents=True, exist_ok=True)
         self._prepare_subtitles()
+        return self.directory, self.subtitle_name, self.out_path
+
+    def subtitles_to_audio(self) -> tuple[Path, Path]:
+        """Convert subtitles to the English audio track."""
         self._convert_subs_to_audio()
+        return self.srt_csv_file, self.stereo_eng_file
+
+    def process_video_file(self, video_path: str) -> None:
+        """Process ``video_path`` by mixing generated audio with the video."""
         self._extract_ukrainian_audio(video_path)
         self._separate_accompaniment()
         self._adjust_volume()
@@ -145,6 +168,29 @@ class SubtitlePipeline:
             for p in Path(root_dir).rglob(f'*.{ext}')
             if not str(p).endswith(exclude_ext)
         ]
+
+    @staticmethod
+    def create_video_with_english_audio(
+        video_path: str,
+        subtitle: Path,
+        speakers: dict,
+        default_speaker: dict,
+        vocabular: Path,
+        acomponiment_coef: float,
+        voice_coef: float,
+        output_folder: Path,
+    ) -> None:
+        """Convenience wrapper used by ``main.py`` for processing a single video."""
+        pipeline = SubtitlePipeline(
+            subtitle,
+            vocabular,
+            speakers,
+            default_speaker,
+            acomponiment_coef,
+            voice_coef,
+            output_folder,
+        )
+        pipeline.run(video_path)
 
 
 


### PR DESCRIPTION
## Summary
- expose public helpers `prepare_subtitles`, `subtitles_to_audio`, `process_video_file`
- update `run` to call these helpers
- add convenience method `create_video_with_english_audio`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884172128b88328ab31abe97973220b