### PR TITLE
Fix .bat script to use package entry point

### DIFF
--- a/tts-recursive_oterra_standart-venv.bat
+++ b/tts-recursive_oterra_standart-venv.bat
@@ -8,7 +8,7 @@ CALL "venv\Scripts\activate.bat"
 
 REM === Main loop ===
 :loop
-python main.py --subtitle "%SUBTITLE_FOLDER%" --output_folder "%SUBTITLE_FOLDER%"
+python -m srt2audiotrack --subtitle "%SUBTITLE_FOLDER%" --output_folder "%SUBTITLE_FOLDER%"
 IF ERRORLEVEL 1 (
     echo [ERROR] Script crashed. Waiting before retry...
     timeout /t 5


### PR DESCRIPTION
## Summary
- update `tts-recursive_oterra_standart-venv.bat` to run the module with `python -m srt2audiotrack`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5d5502e48328ac991fa5dff3d82f