### PR TITLE
Handle missing vocabulary file gracefully

### DIFF
--- a/srt2audiotrack/vocabulary.py
+++ b/srt2audiotrack/vocabulary.py
@@ -3,13 +3,21 @@ from pathlib import Path
 from functools import reduce
 
 def check_vocabular(voice_dir):
+    """Ensure a vocabulary file exists in ``voice_dir``.
+
+    If the ``vocabular.txt`` file is missing, an empty file will be created so
+    the pipeline can continue without manual intervention.  The path to the
+    vocabulary file is always returned.
+    """
+
     vocabular_pth = Path(voice_dir) / "vocabular.txt"
-    if vocabular_pth.is_file():
-        return vocabular_pth
+    if not vocabular_pth.is_file():
+        print(f"Vocabulary file not found at {vocabular_pth}, creating default.")
+        vocabular_pth.parent.mkdir(parents=True, exist_ok=True)
+        vocabular_pth.write_text("", encoding="utf-8")
     else:
-        print(f"I need vocabulary file {vocabular_pth}")
-        exit(1)
-    print(f"Vocabulary file is {vocabular_pth}.")
+        print(f"Vocabulary file is {vocabular_pth}.")
+    return vocabular_pth
 
 def two_cases(title):
     if not title:

--- a/tests/unit/test_vocabulary.py
+++ b/tests/unit/test_vocabulary.py
@@ -1,0 +1,11 @@
+from srt2audiotrack.vocabulary import check_vocabular
+
+
+def test_check_vocabular_creates_file(tmp_path):
+    voice_dir = tmp_path / "VOICE"
+    vocab_path = voice_dir / "vocabular.txt"
+    # voice_dir does not exist and file missing
+    result = check_vocabular(voice_dir)
+    assert result == vocab_path
+    assert vocab_path.exists()
+    assert vocab_path.read_text() == ""


### PR DESCRIPTION
## Summary
- Create an empty `vocabular.txt` when none is present so the pipeline can run without manual setup
- Add unit test covering vocabulary file creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a0f06b1fc832895731ed8aa37e5ae